### PR TITLE
chore: update repository references

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,4 +1,4 @@
-# Copyright The Enterprise Contract Contributors
+# Copyright The Conforma Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate image
-        uses: enterprise-contract/action-validate-image@v1.0.401
+        uses: conforma/action-validate-image@v1.0.401
         with:
           image: ${{ needs.build.outputs.image }}@${{ needs.build.outputs.digest }}
           identity: https:\/\/github\.com\/(slsa-framework\/slsa-github-generator|${{ github.repository_owner }}\/${{ github.event.repository.name }})\/

--- a/Containerfile
+++ b/Containerfile
@@ -4,21 +4,21 @@ ARG GIT_ID
 ARG TARGETARCH
 ARG BUILD_DATE
 
-LABEL name="Enterprise Contract Golden Container" \
+LABEL name="Conforma Golden Container" \
       vendor="Red Hat, Inc." \
-      maintainer="hacbs-contract@redhat.com" \
+      maintainer="conforma@redhat.com" \
       version="1" \
       release="1" \
       build-date=$BUILD_DATE \
-      summary="Trivial image build in compliance with Enterprise Contract policy" \
-      description="Trivial image build in compliance with Enterprise Contract policy" \
-      url="https://github.com/enterprise-contract/golden-container" \
+      summary="Trivial image build in compliance with Conforma policy" \
+      description="Trivial image build in compliance with Conforma policy" \
+      url="https://github.com/conforma/golden-container" \
       distribution-scope="public" \
-      io.k8s.description="Trivial image build in compliance with Enterprise Contract policy" \
-      io.k8s.display-name="Enterprise Contract Contract Golden Container" \
+      io.k8s.description="Trivial image build in compliance with Conforma policy" \
+      io.k8s.display-name="Conforma Golden Container" \
       io.openshift.tags="golden" \
       vcs-ref=$GIT_ID \
       vcs-type=git \
       architecture=$TARGETARCH \
-      com.redhat.component="enterprise-contract-golden-container" \
+      com.redhat.component="conforma-golden-container" \
       com.redhat.build-host="somewhere.over.the.rainbow"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # golden-container
 
-Trivial definition of a multi-arch image build (amd64/arm64) in compliance with Enterprise Contract
+Trivial definition of a multi-arch image build (amd64/arm64) in compliance with Conforma
 policy.
 
 The latest released image is available at `quay.io/konflux-ci/ec-golden-image:latest`.


### PR DESCRIPTION
This commit updates repository references from
`github.com/enterprise-contract/golden-container` to `github.com/conforma/golden-container` across GitHub workflows, Tekton pipelines, and container metadata to reflect the renaming of Enterprise Contract to Conforma

Ref: EC-1107