### PR TITLE
bump action-validate-image version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate image
-        uses: conforma/action-validate-image@v1.0.401
+        uses: conforma/action-validate-image@v1.0.402
         with:
           image: ${{ needs.build.outputs.image }}@${{ needs.build.outputs.digest }}
           identity: https:\/\/github\.com\/(slsa-framework\/slsa-github-generator|${{ github.repository_owner }}\/${{ github.event.repository.name }})\/


### PR DESCRIPTION
This commit bumps the version of the `conforma/action-validate-image` from `1.0.401` to `1.0.402`